### PR TITLE
fixed tag resize on add

### DIFF
--- a/AvaBuddies/ProfileViewController.swift
+++ b/AvaBuddies/ProfileViewController.swift
@@ -40,6 +40,8 @@ class ProfileViewController: UITableViewController, UserDelegate, UICollectionVi
         userRepository?.getUser(refresh: true)
         parent?.title = "Profile".localized()
         parent?.navigationItem.setRightBarButton(saveButton, animated: false)
+        tagsCollection.reloadData()
+        tagsCollection.invalidateIntrinsicContentSize()
     }
     
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
Eerst kreeg je M... als je Milkshake toevoegde als tag aan je profiel en pas als het scherm weer gerefresht werd, werd ie netjes geresized.

Nu krijg je altijd een nette size van de tags te zien